### PR TITLE
Use PLANETSCALE_SERVICE_TOKEN_ID

### DIFF
--- a/.pscale/cli-helper-scripts/use-pscale-docker-image.sh
+++ b/.pscale/cli-helper-scripts/use-pscale-docker-image.sh
@@ -21,7 +21,7 @@ function pscale {
     if [ -n "$NO_DOCKER" ]; then
         command="pscale $@"
     else
-        command="docker run -e PLANETSCALE_SERVICE_TOKEN=$PLANETSCALE_SERVICE_TOKEN -e PLANETSCALE_SERVICE_TOKEN_NAME=$PLANETSCALE_SERVICE_TOKEN_NAME  -e HOME=/tmp -v $HOME/.config/planetscale:/tmp/.config/planetscale -e PSCALE_ALLOW_NONINTERACTIVE_SHELL=true --user $(id -u):$(id -g) --rm -i $tty planetscale/pscale:latest $@"
+        command="docker run -e PLANETSCALE_SERVICE_TOKEN=$PLANETSCALE_SERVICE_TOKEN -e PLANETSCALE_SERVICE_TOKEN_ID=$PLANETSCALE_SERVICE_TOKEN_ID -e PLANETSCALE_SERVICE_TOKEN_NAME=$PLANETSCALE_SERVICE_TOKEN_NAME -e HOME=/tmp -v $HOME/.config/planetscale:/tmp/.config/planetscale -e PSCALE_ALLOW_NONINTERACTIVE_SHELL=true --user $(id -u):$(id -g) --rm -i $tty planetscale/pscale:latest $@"
     fi
 
     # if command is auth and we are running in CI, we will use the script command to get a fake terminal


### PR DESCRIPTION
https://github.com/planetscale/cli/pull/447 makes service token id instead of name mixup less confusing, adopting pscale docker script to support both the old and the new way to pass credentials

kudos to @tbarn for pointing me at the issue