### PR TITLE
Add env variable for pscale version

### DIFF
--- a/.pscale/cli-helper-scripts/use-pscale-docker-image.sh
+++ b/.pscale/cli-helper-scripts/use-pscale-docker-image.sh
@@ -21,7 +21,8 @@ function pscale {
     if [ -n "$NO_DOCKER" ]; then
         command="pscale $@"
     else
-        command="docker run -e PLANETSCALE_SERVICE_TOKEN=$PLANETSCALE_SERVICE_TOKEN -e PLANETSCALE_SERVICE_TOKEN_ID=$PLANETSCALE_SERVICE_TOKEN_ID -e PLANETSCALE_SERVICE_TOKEN_NAME=$PLANETSCALE_SERVICE_TOKEN_NAME -e HOME=/tmp -v $HOME/.config/planetscale:/tmp/.config/planetscale -e PSCALE_ALLOW_NONINTERACTIVE_SHELL=true --user $(id -u):$(id -g) --rm -i $tty planetscale/pscale:latest $@"
+        # For debugging, set PSCALE_VERSION to a version of your choice. It defaults to "latest".
+        command="docker run -e PLANETSCALE_SERVICE_TOKEN=${PLANETSCALE_SERVICE_TOKEN:-""} -e PLANETSCALE_SERVICE_TOKEN_ID=$PLANETSCALE_SERVICE_TOKEN_ID -e PLANETSCALE_SERVICE_TOKEN_NAME=$PLANETSCALE_SERVICE_TOKEN_NAME -e HOME=/tmp -v $HOME/.config/planetscale:/tmp/.config/planetscale -e PSCALE_ALLOW_NONINTERACTIVE_SHELL=true --user $(id -u):$(id -g) --rm -i $tty planetscale/pscale:${PSCALE_VERSION:-"latest"} $@"
     fi
 
     # if command is auth and we are running in CI, we will use the script command to get a fake terminal


### PR DESCRIPTION
This PR adds an environment variable to specify the version for `pscale`. Available options are listed on https://github.com/planetscale/cli/releases.

```
❯ PSCALE_VERSION=v0.63.0 pscale --version
pscale version 0.63.0 (build date: 2021-08-03T18:48:57Z commit: d464d1a)

~ 
❯ pscale --version
pscale version 0.89.0 (build date: 2022-01-24T18:17:47Z commit: 6405542)
```

Note that this is meant for debugging purposes only. You'd always be using the latest and greatest.