### PR TITLE
Fix recursion issue when not using docker

### DIFF
--- a/.pscale/cli-helper-scripts/use-pscale-docker-image.sh
+++ b/.pscale/cli-helper-scripts/use-pscale-docker-image.sh
@@ -17,9 +17,9 @@ function pscale {
         tty=""
     fi
 
-    # if NO_DOCKER is set, we will use the natively installed commands
+    # if NO_DOCKER is set, we will use the locally installed version of pscale
     if [ -n "$NO_DOCKER" ]; then
-        command="pscale $@"
+        command="`which pscale` $@"
     else
         # For debugging, set PSCALE_VERSION to a version of your choice. It defaults to "latest".
         command="docker run -e PLANETSCALE_SERVICE_TOKEN=${PLANETSCALE_SERVICE_TOKEN:-""} -e PLANETSCALE_SERVICE_TOKEN_ID=$PLANETSCALE_SERVICE_TOKEN_ID -e PLANETSCALE_SERVICE_TOKEN_NAME=$PLANETSCALE_SERVICE_TOKEN_NAME -e HOME=/tmp -v $HOME/.config/planetscale:/tmp/.config/planetscale -e PSCALE_ALLOW_NONINTERACTIVE_SHELL=true --user $(id -u):$(id -g) --rm -i $tty planetscale/pscale:${PSCALE_VERSION:-"latest"} $@"


### PR DESCRIPTION
This fixes the recursion issue that could crash your terminal when running `NO_DOCKER=1 pscale`.