### PR TITLE
Descriptive error if org cannot be determined

### DIFF
--- a/.pscale/cli-helper-scripts/set-db-and-org-and-branch-name.sh
+++ b/.pscale/cli-helper-scripts/set-db-and-org-and-branch-name.sh
@@ -6,9 +6,9 @@ echo "Using DB name ${DB_NAME}"
 # set org name to first org the user has access to unless it is already set in ORG_NAME
 if [ -z "${ORG_NAME}" ]; then
     export ORG_NAME=`pscale org list --format json | jq -r ".[0].name"`
-    # check exit code
-    if [ $? -ne 0 ]; then
-        echo "Error: Failed to get PlanetScale org name"
+    # check exit code and name of the org
+    if [ $? -ne 0 ] || [ -z "${ORG_NAME}" ]; then
+        echo "Error: Failed to get PlanetScale org name, please set ORG_NAME explicitly or use Web based SSO, service tokens do not allow to list orgs."
         exit 1
     fi
 fi


### PR DESCRIPTION
* PlanetScale service tokens do not have any scope to list orgs of a user
* if ORG_NAME is not explicitly set, only scopes obtained by pscale auth will allow automated org determination
* write prescriptive error message to set ORG_NAME explicitly in cases where no Web SSO auth was done

/cc @gnumoreno as we figured this out during a trouble shooting session