### PR TITLE
Connection String Generation

### DIFF
--- a/.pscale/cli-helper-scripts/create-branch-connection-string.sh
+++ b/.pscale/cli-helper-scripts/create-branch-connection-string.sh
@@ -33,7 +33,7 @@ function create-branch-connection-string {
         exit 1
     fi
 
-    local DB_URL=`echo "$raw_output" |  jq -r ". | \"mysql://\" + .id +  \":\" + .plain_text +  \"@\" + .database_branch.access_host_url + \"/\""`
+    local DB_URL=`echo "$raw_output" |  jq -r ". | \"mysql://\" + .username +  \":\" + .plain_text +  \"@\" + .database_branch.access_host_url + \"/\""`
     local GENERAL_CONNECTION_STRING=`echo "$raw_output" |  jq -r ". | .connection_strings.general"`
 
 read -r -d '' SECRET_TEXT <<EOF


### PR DESCRIPTION
There appears to have been a change in PlanetScale's systems in the last few days, follow which the `id` property returned from `pscale password create ...` no longer mirrors the `username` property. Connection strings generated now from this `id` return an authentication error when used to connect to a PlanetScale database.